### PR TITLE
luvit requires strictly require bit, math

### DIFF
--- a/luajit-msgpack-pure.lua
+++ b/luajit-msgpack-pure.lua
@@ -1,5 +1,6 @@
 local ffi = require "ffi"
 local bit = require "bit"
+local math = require "math"
 
 -- standard cdefs
 


### PR DESCRIPTION
Hi, when using with luvit, it requires bit and math explicitly.
I checked also on normal luajit2.
