### PR TITLE
Improvements and fixes for luajit msgpack

### DIFF
--- a/luajit-msgpack-pure.lua
+++ b/luajit-msgpack-pure.lua
@@ -565,9 +565,30 @@ local ljp_unpack = function(s,offset)
   return offset,data
 end
 
+local ljp_pack_raw = function(data)
+  sbuffer_init(buffer)
+  packers.dynamic(data)
+  local data, size = buffer.data, buffer.size
+  buffer.data = nil
+  return data, size
+end
+
+local ljp_unpack_raw = function(ptr, size, offset)
+  if offset == nil then offset = 0 end
+  local buffer = {
+    data = ffi.cast("unsigned char *", ptr),
+    size = size
+  }
+  local data
+  offset, data = unpackers.dynamic(buffer, offset)
+  return offset, data
+end
+
 return {
   pack = ljp_pack,
   unpack = ljp_unpack,
+  pack_raw = ljp_pack_raw,
+  unpack_raw = ljp_unpack_raw,
   set_fp_type = set_fp_type,
   table_classifiers = {
     keys = table_classifier_keys,


### PR DESCRIPTION
The patchset includes several fixes and improvements that let us use this module in our environment. The first patch fixes segmentation faults error if we pass an uncompleted stream buffer for unpacking. The second patch allows to work with raw C pointers. The third patch fixes our scenario where floating point precision was truncated randomly.